### PR TITLE
Redirect Status Code '0' to error callback

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -111,9 +111,7 @@ iron-request can be used to perform XMLHttpRequests.
 
     /**
      * Succeeded is true if the request succeeded. The request succeeded if the
-     * status code is greater-than-or-equal-to 200, and less-than 300. Also,
-     * the status code 0 is accepted as a success even though the outcome may
-     * be ambiguous.
+     * status code is greater-than-or-equal-to 200, and less-than 300. 
      *
      * @return {boolean}
      */

--- a/iron-request.html
+++ b/iron-request.html
@@ -122,8 +122,7 @@ iron-request can be used to perform XMLHttpRequests.
 
       // Note: if we are using the file:// protocol, the status code will be 0
       // for all outcomes (successful or otherwise).
-      return status === 0 ||
-        (status >= 200 && status < 300);
+      return (status >= 200 && status < 300);
     },
 
     /**


### PR DESCRIPTION
Pros:
* 'ERR_INTERNET_DISCONNECTED' no longer calls the success callback

Cons:
* Canceling a request will also call the error callback instead of the success callback